### PR TITLE
Improve Use with Scripts / Automation

### DIFF
--- a/src/odsc.psm1
+++ b/src/odsc.psm1
@@ -3,6 +3,8 @@
 $Public = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath "\public\*.ps1") -ErrorAction SilentlyContinue)
 $Private = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath "\private\*.ps1") -ErrorAction SilentlyContinue)
 
+$script:ODSToken = $null
+
 foreach ($Import in @($Public + $Private)) {
     try {
         Write-Verbose "Importing file: $($Import.FullName)"
@@ -14,4 +16,11 @@ foreach ($Import in @($Public + $Private)) {
 
 foreach ($File in $Public) {
     Export-ModuleMember -Function $File.BaseName
+}
+
+# Register module removal event handler
+$MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
+    # Clear sensitive data when module is removed
+    Write-Verbose "Clearing ODSC authentication token"
+    $script:ODSToken = $null
 }

--- a/src/private/Invoke-odscApiRequest.ps1
+++ b/src/private/Invoke-odscApiRequest.ps1
@@ -15,7 +15,7 @@ function Invoke-odscApiRequest {
     )
 
     begin {
-        $Token = $PsCmdlet.SessionState.PSVariable.GetValue('_ODSToken')
+        $Token = $script:ODSToken
 
         if ((!$Token.ExpiresOn) -or 
         (!$Token.AccessToken) -or

--- a/src/public/Connect-odsc.ps1
+++ b/src/public/Connect-odsc.ps1
@@ -22,7 +22,7 @@ function Connect-odsc {
     )
 
     begin {
-        $Token = $null
+
     }
 
     process {
@@ -30,7 +30,7 @@ function Connect-odsc {
             'ClientSecret' {
                 try {
                     $Token = Get-MsalToken -ClientId $ClientId -TenantId $TenantId -ClientSecret $ClientSecret -AzureCloudInstance $AzureCloudInstance
-                    $PsCmdlet.SessionState.PSVariable.Set('_ODSToken', $Token)
+                    $script:ODSToken = $Token
                 } catch {
                     Write-Verbose $_
                     Write-Error "Token request using ClientSecret failed." -ErrorAction Stop
@@ -39,7 +39,7 @@ function Connect-odsc {
             'ClientCertificate' {
                 try {
                     $Token = Get-MsalToken -ClientId $ClientId -TenantId $TenantId -ClientCertificate $ClientCertificate -AzureCloudInstance $AzureCloudInstance
-                    $PsCmdlet.SessionState.PSVariable.Set('_ODSToken', $Token)
+                    $script:ODSToken = $Token
                 } catch {
                     Write-Verbose $_
                     Write-Error "Token request using ClientCertificate failed." -ErrorAction Stop

--- a/src/public/Disconnect-odsc.ps1
+++ b/src/public/Disconnect-odsc.ps1
@@ -7,7 +7,7 @@ function Disconnect-odsc {
     }
 
     process {
-        $PsCmdlet.SessionState.PSVariable.Set('_ODSToken', $null)
+        $script:ODSToken = $null
     }
 
     end {


### PR DESCRIPTION
First PR, hopefully all is correct here.

Move ODSToken provided by MSAL to a module / script level variable to allow the use of Connect-odsc in scripts and have the token properly pass between modules for authentication.

Removed a hard coded ```-erroraction stop``` in Get-odsc to allow iteration across a set of UPNs where some users may have the shortcut and some may not.

Example script used to validate multi-run scenarios included (GUIDs are already sanitized):

```
$UserPrincipalName = "example@mytenant.com"
$SharePoint = "https://mytenant.sharepoint.com/sites/Finance"
$DocumentLibrary = "Finance Documents"
$FolderPath = "Finance"
$ShortcutName = "Finance - Super Secret Documents"
$TenantId = "90a2521a-019b-4242-a68f-281b98b7bc42"
$ClientId = "90a2521a-019b-4242-a68f-281b98b7bc42"
$ClientSecret = Get-Secret -Name "MyClientSecret"

Write-Host "Importing ODSC module..."
Import-Module -name ./src/odsc.psm1 -force

Write-Host "Connecting to SharePoint..."
Connect-odsc -TenantId $TenantId -ClientId $ClientId -ClientSecret $ClientSecret

$shortcutExists = get-odsc -ShortcutName $ShortcutName -UserPrincipalName $UserPrincipalName -ErrorAction SilentlyContinue

# If the shortcut already exists remove it for testing
if ($shortcutExists) {
    Remove-odsc -ShortcutName $ShortcutName -UserPrincipalName $UserPrincipalName
    Write-Host "Shortcut '$ShortcutName' removed."
}

$ShortcutCreationResult = New-odsc -Uri $SharePoint -DocumentLibrary $DocumentLibrary -FolderPath $FolderPath -ShortcutName $ShortcutName -UserPrincipalName $UserPrincipalName

If ($ShortcutCreationResult) {
    Write-Host "Shortcut '$ShortcutName' created successfully."
} else {
    Write-Error "Failed to create shortcut '$ShortcutName'."
}
```